### PR TITLE
fix UndefinedConversionError when updating the feed

### DIFF
--- a/lib/phishtank/feed_request.rb
+++ b/lib/phishtank/feed_request.rb
@@ -1,5 +1,5 @@
 module PhishTank
-  class FeedRequest    
+  class FeedRequest
     attr_accessor :etag
     
     def initialize(etag = nil)
@@ -14,9 +14,9 @@ module PhishTank
     
     def get_update
       response = get(update_uri)
-      file = File.new("#{PhishTank.configuration.temp_directory}/online-valid.xml", 'w')
-      file.puts response.body
-      file.close
+      File.open("#{PhishTank.configuration.temp_directory}/online-valid.xml", 'wb') do |file|
+        file.write(response.body)
+      end
     end
     
     def update_uri


### PR DESCRIPTION
This commit fixes some encoding errors during the feed download. Also, you download the whole file (~40 mb) into the memory first, I'm not sure how to fix it using just typhoeus.
